### PR TITLE
Fix unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
 				"@sveltejs/kit": "^2.16.0",
 				"@sveltejs/vite-plugin-svelte": "^5.0.0",
 				"@tailwindcss/vite": "^4.0.0",
-				"dotenv": "^17.2.3",
 				"eslint": "^9.39.1",
 				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-svelte": "^3.13.0",
@@ -2309,19 +2308,6 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
-			}
-		},
-		"node_modules/dotenv": {
-			"version": "17.2.3",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
-			"integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/eastasianwidth": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
 				"svelte": "^5.0.0",
 				"svelte-check": "^4.0.0",
 				"tailwindcss": "^4.0.0",
+				"tsx": "^4.19.2",
 				"typescript": "5.9.3",
 				"typescript-eslint": "^8.48.0",
 				"vite": "^6.2.6"
@@ -2829,6 +2830,19 @@
 				"node": "6.* || 8.* || >= 10.*"
 			}
 		},
+		"node_modules/get-tsconfig": {
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
+			"integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"resolve-pkg-maps": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+			}
+		},
 		"node_modules/glob": {
 			"version": "10.5.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -4055,6 +4069,16 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/resolve-pkg-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+			}
+		},
 		"node_modules/rollup": {
 			"version": "4.53.3",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
@@ -4524,6 +4548,510 @@
 			},
 			"peerDependencies": {
 				"typescript": ">=4.8.4"
+			}
+		},
+		"node_modules/tsx": {
+			"version": "4.21.0",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "~0.27.0",
+				"get-tsconfig": "^4.7.5"
+			},
+			"bin": {
+				"tsx": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+			"integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/android-arm": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+			"integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/android-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+			"integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/android-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+			"integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+			"integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+			"integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+			"integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+			"integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-arm": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+			"integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+			"integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+			"integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+			"integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+			"integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+			"integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+			"integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+			"integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+			"integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+			"integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+			"integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+			"integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+			"integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+			"integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+			"integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+			"integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+			"integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/win32-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+			"integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/esbuild": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+			"integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.27.2",
+				"@esbuild/android-arm": "0.27.2",
+				"@esbuild/android-arm64": "0.27.2",
+				"@esbuild/android-x64": "0.27.2",
+				"@esbuild/darwin-arm64": "0.27.2",
+				"@esbuild/darwin-x64": "0.27.2",
+				"@esbuild/freebsd-arm64": "0.27.2",
+				"@esbuild/freebsd-x64": "0.27.2",
+				"@esbuild/linux-arm": "0.27.2",
+				"@esbuild/linux-arm64": "0.27.2",
+				"@esbuild/linux-ia32": "0.27.2",
+				"@esbuild/linux-loong64": "0.27.2",
+				"@esbuild/linux-mips64el": "0.27.2",
+				"@esbuild/linux-ppc64": "0.27.2",
+				"@esbuild/linux-riscv64": "0.27.2",
+				"@esbuild/linux-s390x": "0.27.2",
+				"@esbuild/linux-x64": "0.27.2",
+				"@esbuild/netbsd-arm64": "0.27.2",
+				"@esbuild/netbsd-x64": "0.27.2",
+				"@esbuild/openbsd-arm64": "0.27.2",
+				"@esbuild/openbsd-x64": "0.27.2",
+				"@esbuild/openharmony-arm64": "0.27.2",
+				"@esbuild/sunos-x64": "0.27.2",
+				"@esbuild/win32-arm64": "0.27.2",
+				"@esbuild/win32-ia32": "0.27.2",
+				"@esbuild/win32-x64": "0.27.2"
 			}
 		},
 		"node_modules/tw-animate-css": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 				"@sveltejs/kit": "^2.16.0",
 				"@sveltejs/vite-plugin-svelte": "^5.0.0",
 				"@tailwindcss/vite": "^4.0.0",
+				"dotenv": "^17.2.3",
 				"eslint": "^9.39.1",
 				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-svelte": "^3.13.0",
@@ -947,7 +948,6 @@
 			"integrity": "sha512-JXmM4XCoso6C75Mr3lhKA3eNxSzkYi3nCzxDIKY+YOszYsJjuKbFgVtguVPbLMOttN4iu2fXoc2BGhdnYhIOxA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cluster-key-slot": "1.1.2"
 			},
@@ -1321,7 +1321,6 @@
 			"integrity": "sha512-oH8tXw7EZnie8FdOWYrF7Yn4IKrqTFHhXvl8YxXxbKwTMcD/5NNCryUSEXRk2ZR4ojnub0P8rNrsVGHXWqIDtA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
@@ -1361,7 +1360,6 @@
 			"integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
 				"debug": "^4.4.1",
@@ -1722,7 +1720,6 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.48.0.tgz",
 			"integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.48.0",
 				"@typescript-eslint/types": "8.48.0",
@@ -1919,7 +1916,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2314,6 +2310,19 @@
 				"node": ">=0.3.1"
 			}
 		},
+		"node_modules/dotenv": {
+			"version": "17.2.3",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+			"integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
 		"node_modules/eastasianwidth": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2411,7 +2420,6 @@
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
 			"integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -3702,7 +3710,6 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -3730,7 +3737,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -3863,7 +3869,6 @@
 			"integrity": "sha512-RWKXE4qB3u5Z6yz7omJkjWwmTfLdcbv44jUVHC5NpfXwFGzvpQM798FGv/6WNK879tc+Cn0AAyherCl1KjbyZQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -3880,7 +3885,6 @@
 			"integrity": "sha512-pn1ra/0mPObzqoIQn/vUTR3ZZI6UuZ0sHqMK5x2jMLGrs53h0sXhkVuDcrlssHwIMk7FYrMjHBPoUSyyEEDlBQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"prettier": "^3.0.0",
 				"svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
@@ -4375,7 +4379,6 @@
 			"integrity": "sha512-yyXdW2u3H0H/zxxWoGwJoQlRgaSJLp+Vhktv12iRw2WRDlKqUPT54Fi0K/PkXqrdkcQ98aBazpy0AH4BCBVfoA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -4549,7 +4552,6 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -4617,7 +4619,6 @@
 			"integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.4.4",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"@sveltejs/kit": "^2.16.0",
 		"@sveltejs/vite-plugin-svelte": "^5.0.0",
 		"@tailwindcss/vite": "^4.0.0",
+		"dotenv": "^17.2.3",
 		"eslint": "^9.39.1",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-svelte": "^3.13.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"lint": "eslint . --max-warnings=0",
-		"test": "mocha",
+		"test": "mocha --require tsx/cjs",
 		"format": "prettier --write ."
 	},
 	"devDependencies": {
@@ -29,6 +29,7 @@
 		"globals": "^16.5.0",
 		"lucide-svelte": "latest",
 		"mocha": "^11.7.5",
+		"tsx": "^4.19.2",
 		"prettier": "^3.4.2",
 		"prettier-plugin-svelte": "^3.3.3",
 		"prettier-plugin-tailwindcss": "^0.6.11",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
 		"@sveltejs/kit": "^2.16.0",
 		"@sveltejs/vite-plugin-svelte": "^5.0.0",
 		"@tailwindcss/vite": "^4.0.0",
-		"dotenv": "^17.2.3",
 		"eslint": "^9.39.1",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-svelte": "^3.13.0",

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,33 @@
 import assert from "assert";
-import { plants } from "../src/lib/plant-data.ts";
+import dotenv from "dotenv";
+import { calculateConditionStatus } from "../src/lib/utils/plant-helpers.ts";
+
+dotenv.config();
+const API_URL = process.env.PUBLIC_API_URL || "http://localhost:3011";
+
+// Fetch alle forests met de plants
+async function fetchAllForests() {
+  try {
+    const forestsResponse = await fetch(`${API_URL}/forests/api/v1/forests`);
+    const forestsData = await forestsResponse.json();
+    
+    if (!forestsData?.data || forestsData.data.length === 0) {
+      return [];
+    }
+    
+    // Pak forest data van alle forests
+    const forestPromises = forestsData.data.map(forest => 
+      fetch(`${API_URL}/forests/api/v1/forests/${forest.id}`).then(res => res.json())
+    );
+    
+    const allForests = await Promise.all(forestPromises);
+    return allForests.map(f => f.data);
+  } catch (error) {
+    console.error("Error fetching forest data:", error);
+    throw error;
+  }
+}
+
 //voorbeeld test
 describe("#voorbeeld test", function () {
   it("2 + 2 is gelijk aan 4", function () {
@@ -9,27 +37,122 @@ describe("#voorbeeld test", function () {
 
 // Test of de plants array niet leeg is
 describe("Planten data tests", function () {
-  it("plants array bevat items", function () {
-    assert.ok(plants.length > 0);
+  let allForests;
+
+  // Doet fetch calls voordat tests beginnen
+  before(async function () {
+    this.timeout(10000);
+    allForests = await fetchAllForests();
   });
 
-  // Test of de planten een naam hebben
+  it("minimaal 1 forest bevat planten", function () {
+    assert.ok(allForests.length > 0, "Er moet minimaal 1 forest zijn");
+    
+    const hasForestWithPlants = allForests.some(forest => {
+      const hasPlants = forest.plants && forest.plants.length > 0;
+      return hasPlants;
+    });
+    assert.ok(hasForestWithPlants, "Minimaal 1 forest moet plants hebben");
+  });
+
+  // Test of de planten een naam hebben 
   it("elke plant heeft een naam", function () {
-    plants.forEach((plant) => {
-      assert.ok(plant.name);
+    assert.ok(allForests.length > 0, "Er zijn geen forests");
+    
+    allForests.forEach((forest, forestIndex) => {
+      if (forest.plants && forest.plants.length > 0) {
+        forest.plants.forEach((plant) => {
+          const plantName = plant.name || plant.species?.name;
+          assert.ok(plantName, `Forest ${forestIndex}: Plant met ID ${plant.id} moet een naam hebben`);
+        });
+      }
     });
   });
 
-  // Test of geen planten op dezelfde plek staan (dus op zelfde x en y cordinaten)
+  // Test of geen planten op dezelfde plek staan
   it("planten overlappen niet", function () {
-    plants.forEach((plant1, index) => {
-      plants.slice(index + 1).forEach((plant2) => {
-        // Check of die x en y coordinaten het zelfde zijn
-        const zelfdePositie = plant1.position.x === plant2.position.x && 
-                              plant1.position.y === plant2.position.y;
-        assert.ok(!zelfdePositie, 
-          `Plant "${plant1.name}" en "${plant2.name}" staan op dezelfde plek`);
-      });
+    assert.ok(allForests.length > 0, "Er zijn geen forests");
+    
+    allForests.forEach((forest, forestIndex) => {
+      if (forest.plants && forest.plants.length > 1) {
+        const plants = forest.plants;
+        
+        plants.forEach((plant1, index) => {
+          plants.slice(index + 1).forEach((plant2) => {
+            const zelfdePositie = plant1.posX === plant2.posX && 
+                                  plant1.posY === plant2.posY;
+            assert.ok(!zelfdePositie, 
+              `Forest ${forestIndex}: Plant ${plant1.id} en Plant ${plant2.id} staan op dezelfde plek`);
+          });
+        });
+      }
     });
+  });
+
+  // Test of elke plant een species heeft in alle forests
+  it("elke plant heeft species informatie in alle forests", function () {
+    assert.ok(allForests.length > 0, "Er zijn geen forests");
+    
+    allForests.forEach((forest, forestIndex) => {
+      if (forest.plants && forest.plants.length > 0) {
+        forest.plants.forEach((plant) => {
+          const plantName = plant.name || plant.species?.name || `Plant ${plant.id}`;
+          assert.ok(plant.species, `Forest ${forestIndex}: Plant "${plantName}" moet species informatie hebben`);
+          assert.ok(plant.species.name, `Forest ${forestIndex}: Plant "${plantName}" moet een species naam hebben`);
+        });
+      }
+    });
+  });
+});
+
+// Frontend utility tests
+describe("Tests Frontend logica", function () {
+  
+  // checkt of de plant condition logica klopt
+  it("calculateConditionStatus geeft 'optimal' als alles binnen range is", function () {
+    const conditions = {
+      temperature: 22,
+      humidity: 60,
+      soilMoisture: 50,
+      sunlight: 8
+    };
+    
+    const species = {
+      minTemperature: 15,
+      maxTemperature: 30,
+      minHumidity: 40,
+      maxHumidity: 80,
+      minSoilMoisture: 30,
+      maxSoilMoisture: 70,
+      minSunlight: 5,
+      maxSunlight: 10
+    };
+    
+    const result = calculateConditionStatus(conditions, species);
+    assert.equal(result, 'optimal', "Status moet 'optimal' zijn als alle conditions binnen range zijn");
+  });
+  
+  // checkt critical status wanneer alle conditions fout zijn is
+  it("calculateConditionStatus geeft 'critical' als alles buiten range is", function () {
+    const conditions = {
+      temperature: 50,    
+      humidity: 10,       
+      soilMoisture: 100,  
+      sunlight: 0         
+    };
+    
+    const species = {
+      minTemperature: 15,
+      maxTemperature: 30,
+      minHumidity: 40,
+      maxHumidity: 80,
+      minSoilMoisture: 30,
+      maxSoilMoisture: 70,
+      minSunlight: 5,
+      maxSunlight: 10
+    };
+    
+    const result = calculateConditionStatus(conditions, species);
+    assert.equal(result, 'critical', "Status moet 'critical' zijn als alle conditions buiten range zijn");
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -10,18 +10,20 @@ async function fetchAllForests() {
   try {
     const forestsResponse = await fetch(`${API_URL}/forests/api/v1/forests`);
     const forestsData = await forestsResponse.json();
-    
+
     if (!forestsData?.data || forestsData.data.length === 0) {
       return [];
     }
-    
+
     // Pak forest data van alle forests
-    const forestPromises = forestsData.data.map(forest => 
-      fetch(`${API_URL}/forests/api/v1/forests/${forest.id}`).then(res => res.json())
+    const forestPromises = forestsData.data.map((forest) =>
+      fetch(`${API_URL}/forests/api/v1/forests/${forest.id}`).then((res) =>
+        res.json(),
+      ),
     );
-    
+
     const allForests = await Promise.all(forestPromises);
-    return allForests.map(f => f.data);
+    return allForests.map((f) => f.data);
   } catch (error) {
     console.error("Error fetching forest data:", error);
     throw error;
@@ -47,23 +49,26 @@ describe("Planten data tests", function () {
 
   it("minimaal 1 forest bevat planten", function () {
     assert.ok(allForests.length > 0, "Er moet minimaal 1 forest zijn");
-    
-    const hasForestWithPlants = allForests.some(forest => {
+
+    const hasForestWithPlants = allForests.some((forest) => {
       const hasPlants = forest.plants && forest.plants.length > 0;
       return hasPlants;
     });
     assert.ok(hasForestWithPlants, "Minimaal 1 forest moet plants hebben");
   });
 
-  // Test of de planten een naam hebben 
+  // Test of de planten een naam hebben
   it("elke plant heeft een naam", function () {
     assert.ok(allForests.length > 0, "Er zijn geen forests");
-    
+
     allForests.forEach((forest, forestIndex) => {
       if (forest.plants && forest.plants.length > 0) {
         forest.plants.forEach((plant) => {
           const plantName = plant.name || plant.species?.name;
-          assert.ok(plantName, `Forest ${forestIndex}: Plant met ID ${plant.id} moet een naam hebben`);
+          assert.ok(
+            plantName,
+            `Forest ${forestIndex}: Plant met ID ${plant.id} moet een naam hebben`,
+          );
         });
       }
     });
@@ -72,17 +77,19 @@ describe("Planten data tests", function () {
   // Test of geen planten op dezelfde plek staan
   it("planten overlappen niet", function () {
     assert.ok(allForests.length > 0, "Er zijn geen forests");
-    
+
     allForests.forEach((forest, forestIndex) => {
       if (forest.plants && forest.plants.length > 1) {
         const plants = forest.plants;
-        
+
         plants.forEach((plant1, index) => {
           plants.slice(index + 1).forEach((plant2) => {
-            const zelfdePositie = plant1.posX === plant2.posX && 
-                                  plant1.posY === plant2.posY;
-            assert.ok(!zelfdePositie, 
-              `Forest ${forestIndex}: Plant ${plant1.id} en Plant ${plant2.id} staan op dezelfde plek`);
+            const zelfdePositie =
+              plant1.posX === plant2.posX && plant1.posY === plant2.posY;
+            assert.ok(
+              !zelfdePositie,
+              `Forest ${forestIndex}: Plant ${plant1.id} en Plant ${plant2.id} staan op dezelfde plek`,
+            );
           });
         });
       }
@@ -92,13 +99,20 @@ describe("Planten data tests", function () {
   // Test of elke plant een species heeft in alle forests
   it("elke plant heeft species informatie in alle forests", function () {
     assert.ok(allForests.length > 0, "Er zijn geen forests");
-    
+
     allForests.forEach((forest, forestIndex) => {
       if (forest.plants && forest.plants.length > 0) {
         forest.plants.forEach((plant) => {
-          const plantName = plant.name || plant.species?.name || `Plant ${plant.id}`;
-          assert.ok(plant.species, `Forest ${forestIndex}: Plant "${plantName}" moet species informatie hebben`);
-          assert.ok(plant.species.name, `Forest ${forestIndex}: Plant "${plantName}" moet een species naam hebben`);
+          const plantName =
+            plant.name || plant.species?.name || `Plant ${plant.id}`;
+          assert.ok(
+            plant.species,
+            `Forest ${forestIndex}: Plant "${plantName}" moet species informatie hebben`,
+          );
+          assert.ok(
+            plant.species.name,
+            `Forest ${forestIndex}: Plant "${plantName}" moet een species naam hebben`,
+          );
         });
       }
     });
@@ -107,16 +121,15 @@ describe("Planten data tests", function () {
 
 // Frontend utility tests
 describe("Tests Frontend logica", function () {
-  
   // checkt of de plant condition logica klopt
   it("calculateConditionStatus geeft 'optimal' als alles binnen range is", function () {
     const conditions = {
       temperature: 22,
       humidity: 60,
       soilMoisture: 50,
-      sunlight: 8
+      sunlight: 8,
     };
-    
+
     const species = {
       minTemperature: 15,
       maxTemperature: 30,
@@ -125,22 +138,26 @@ describe("Tests Frontend logica", function () {
       minSoilMoisture: 30,
       maxSoilMoisture: 70,
       minSunlight: 5,
-      maxSunlight: 10
+      maxSunlight: 10,
     };
-    
+
     const result = calculateConditionStatus(conditions, species);
-    assert.equal(result, 'optimal', "Status moet 'optimal' zijn als alle conditions binnen range zijn");
+    assert.equal(
+      result,
+      "optimal",
+      "Status moet 'optimal' zijn als alle conditions binnen range zijn",
+    );
   });
-  
+
   // checkt critical status wanneer alle conditions fout zijn is
   it("calculateConditionStatus geeft 'critical' als alles buiten range is", function () {
     const conditions = {
-      temperature: 50,    
-      humidity: 10,       
-      soilMoisture: 100,  
-      sunlight: 0         
+      temperature: 50,
+      humidity: 10,
+      soilMoisture: 100,
+      sunlight: 0,
     };
-    
+
     const species = {
       minTemperature: 15,
       maxTemperature: 30,
@@ -149,10 +166,14 @@ describe("Tests Frontend logica", function () {
       minSoilMoisture: 30,
       maxSoilMoisture: 70,
       minSunlight: 5,
-      maxSunlight: 10
+      maxSunlight: 10,
     };
-    
+
     const result = calculateConditionStatus(conditions, species);
-    assert.equal(result, 'critical', "Status moet 'critical' zijn als alle conditions buiten range zijn");
+    assert.equal(
+      result,
+      "critical",
+      "Status moet 'critical' zijn als alle conditions buiten range zijn",
+    );
   });
 });


### PR DESCRIPTION
De unit tests fetchen nu data vanaf de backend en doen dan de tests. Er zijn 2 nieuwe tests toegevoegd, deze checken of de logica klopt van calculateConditionStatus.

Note: Mocha kan niet de sveltekit functies importen ofzo. Daarom kan ik (voor zover ik weet) niet de fetchLatest functie gebruiken uit forest-data.ts. Nu word de data gewoon gefetched in test.js. Als iemand een handigere oplossing weet hoor ik het graag.